### PR TITLE
fix font-face format

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -47,7 +47,7 @@ input,textarea{
 /* fonts */
 @font-face {
   font-family: 'Rubik Regular';
-  src: url("assets/fonts/Rubik-Regular.ttf") format("ttf"),
+  src: url("assets/fonts/Rubik-Regular.ttf") format("truetype");
 }
 h1,h2,h3,h4{
   color: #DDDBFF;


### PR DESCRIPTION
Based on [MDN reference about @font-face](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face), the valid format type for TrueType font is 'truetype'. By the way, I've fixed the comma at the end. I think these changes need to be applied to the following lessons too :D
Thank you for your awesome tutorial.